### PR TITLE
CH01 - Basic tuple support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.14.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: go test -v ./...

--- a/features/tuple.feature
+++ b/features/tuple.feature
@@ -1,0 +1,35 @@
+Feature: Tuples, Vectors, and Points
+
+Scenario: A tuple with w=1.0 is a point
+  Given a ← tuple(4.3, -4.2, 3.1, 1.0)
+  Then a.x = 4.3
+    And a.y = -4.2
+    And a.z = 3.1
+    And a.w = 1.0
+    And a is a point
+    And a is not a vector
+
+Scenario: A tuple with w=0 is a vector
+  Given a ← tuple(4.3, -4.2, 3.1, 0.0)
+  Then a.x = 4.3
+    And a.y = -4.2
+    And a.z = 3.1
+    And a.w = 0.0
+    And a is not a point
+    And a is a vector
+
+Scenario: A vector tuple is a vector
+  Given a ← vector(4.3, -4.2, 3.1)
+  Then a.x = 4.3
+    And a.y = -4.2
+    And a.z = 3.1
+    And a is not a point
+    And a is a vector
+
+Scenario: A point tuple is a point
+  Given a ← point(4.3, -4.2, 3.1)
+  Then a.x = 4.3
+    And a.y = -4.2
+    And a.z = 3.1
+    And a is a point
+    And a is not a vector

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/dougnukem/raytracer
+
+go 1.14
+
+require github.com/cucumber/godog v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/cucumber/godog v0.8.1 h1:lVb+X41I4YDreE+ibZ50bdXmySxgRviYFgKY6Aw4XE8=
+github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Printf("dougnukem's ray tracer\n")
+}

--- a/tuple.go
+++ b/tuple.go
@@ -1,0 +1,29 @@
+package main
+
+// Tuple represents a 3D point (W=1.0) or a vector (W=0.0)
+type Tuple struct {
+	X float64
+	Y float64
+	Z float64
+	W float64
+}
+
+// NewPoint creates a new point represented by a 3D Tuple
+func NewPoint(x, y, z float64) *Tuple {
+	return &Tuple{x, y, z, 1.0}
+}
+
+// NewVector creates a new vector represented by a 3D Tuple
+func NewVector(x, y, z float64) *Tuple {
+	return &Tuple{x, y, z, 0.0}
+}
+
+// IsPoint if tuple is a point
+func (t *Tuple) IsPoint() bool {
+	return t.W == 1.0
+}
+
+// IsVector if tuple is a vector
+func (t *Tuple) IsVector() bool {
+	return t.W == 0.0
+}

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/colors"
+)
+
+var opt = godog.Options{Output: colors.Colored(os.Stdout)}
+
+func init() {
+	godog.BindFlags("godog.", flag.CommandLine, &opt)
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	opt.Paths = flag.Args()
+
+	status := godog.RunWithOptions("godogs", func(s *godog.Suite) {
+		FeatureContext(s)
+	}, opt)
+
+	if st := m.Run(); st > status {
+		status = st
+	}
+	os.Exit(status)
+}
+
+var tuple *Tuple
+
+func aTuple(x, y, z, w float64) error {
+	tuple = &Tuple{x, y, z, w}
+	return nil
+}
+
+func aVector(x, y, z float64) error {
+	tuple = NewVector(x, y, z)
+	return nil
+}
+
+func aPoint(x, y, z float64) error {
+	tuple = NewPoint(x, y, z)
+	return nil
+}
+
+func ax(x float64) error {
+	if tuple.X != x {
+		return fmt.Errorf("expected a.x to equal %f but was %f", x, tuple.X)
+	}
+	return nil
+}
+
+func ay(expected float64) error {
+	if tuple.Y != expected {
+		return fmt.Errorf("expected a.y to equal %f but was %f", expected, tuple.Y)
+	}
+	return nil
+}
+
+func az(expected float64) error {
+	if tuple.Z != expected {
+		return fmt.Errorf("expected a.z to equal %f but was %f", expected, tuple.Z)
+	}
+	return nil
+}
+
+func aw(expected float64) error {
+	if tuple.W != expected {
+		return fmt.Errorf("expected a.w to equal %f but was %f", expected, tuple.W)
+	}
+	return nil
+}
+
+func aIsAPoint() error {
+	if !tuple.IsPoint() {
+		return fmt.Errorf("expected a to be a Point but it was not: %v", tuple)
+	}
+	return nil
+}
+
+func aIsNotAVector() error {
+	if tuple.IsVector() {
+		return fmt.Errorf("expected a to not be a Vector but it was: %v", tuple)
+	}
+	return nil
+}
+
+func aIsNotAPoint() error {
+	if tuple.IsPoint() {
+		return fmt.Errorf("expected a to not be a Point but it was: %v", tuple)
+	}
+	return nil
+}
+
+func aIsAVector() error {
+	if !tuple.IsVector() {
+		return fmt.Errorf("expected a to be a Vector but it was not: %v", tuple)
+	}
+	return nil
+}
+
+func FeatureContext(s *godog.Suite) {
+	s.Step(`^a ← tuple\((\-*\d+\.\d+), (\-*\d+\.\d+), (\-*\d+\.\d+), (\-*\d+\.\d+)\)$`, aTuple)
+	s.Step(`^a ← vector\((\-*\d+\.\d+), (\-*\d+\.\d+), (\-*\d+\.\d+)\)$`, aVector)
+	s.Step(`^a ← point\((\-*\d+\.\d+), (\-*\d+\.\d+), (\-*\d+\.\d+)\)$`, aPoint)
+	s.Step(`^a\.x = (\-*\d+\.\d+)$`, ax)
+	s.Step(`^a\.y = (\-*\d+\.\d+)$`, ay)
+	s.Step(`^a\.z = (\-*\d+\.\d+)$`, az)
+	s.Step(`^a\.w = (\-*\d+\.\d+)$`, aw)
+	s.Step(`^a is a point$`, aIsAPoint)
+	s.Step(`^a is not a vector$`, aIsNotAVector)
+	s.Step(`^a is not a point$`, aIsNotAPoint)
+	s.Step(`^a is a vector$`, aIsAVector)
+	s.BeforeScenario(func(i interface{}) {
+		tuple = nil // clean the state before every scenario
+	})
+}
+
+func TestTuple(t *testing.T) {
+	// stub test, godog will run Cucumber/Gherkin BDD tests in ./features
+}


### PR DESCRIPTION
Add support for `Tuple` and BDD unit tests using [godog](https://github.com/cucumber/godog) (Cucumber/Gherkin) based.

https://github.com/dougnukem/raytracer/blob/a231008e51160fc408f9d4bb278b85c6de9934ba/tuple.go#L3-L9